### PR TITLE
Support multiple compute node images

### DIFF
--- a/environments/deploy/terraform/main.tf
+++ b/environments/deploy/terraform/main.tf
@@ -286,8 +286,8 @@ resource "openstack_compute_instance_v2" "computes" {
   for_each = var.compute_names
 
   name = "${var.cluster_name}-${each.key}"
-  image_name = var.compute_image
-  flavor_name = each.value
+  image_name = lookup(var.compute_images, each.key, var.compute_types[each.value].image)
+  flavor_name = var.compute_types[each.value].flavor
   key_pair = var.key_pair
   config_drive = true
 

--- a/environments/deploy/terraform/terraform.tfvars
+++ b/environments/deploy/terraform/terraform.tfvars
@@ -1,17 +1,40 @@
+compute_types = {
+  large: {
+    flavor: "compute.c60m240s120e1000"
+    image: "CentOS8.3"
+  }
+  standard: {
+    flavor: "compute.c30m120s60e500"
+    image: "CentOS8.3"
+  }
+  small: {
+    flavor: "compute.c16m64s32e250"
+    image: "CentOS8.3"
+  }
+  tiny: {
+    flavor: "compute.c4m16s8e60"
+    image: "CentOS8.3"
+  }
+  gpu: {
+    flavor: "gpu.c30m120s32e6000"
+    image: "CentOS8.3"
+  }
+}
+
 compute_names = {
-  lg-0001: "compute.c60m240s120e1000"
-  lg-0002: "compute.c60m240s120e1000"
+  lg-0001: "large"
+  lg-0002: "large"
 
-  std-0001: "compute.c30m120s60e500"
-  std-0002: "compute.c30m120s60e500"
+  std-0001: "standard"
+  std-0002: "standard"
 
-  sm-0001: "compute.c16m64s32e250"
-  sm-0002: "compute.c16m64s32e250"
+  sm-0001: "small"
+  sm-0002: "small"
 
-  t-0001: "compute.c4m16s8e60"
-  t-0002: "compute.c4m16s8e60"
+  t-0001: "tiny"
+  t-0002: "tiny"
 
-  gpu-0001: "gpu.c30m120s32e6000"
+  gpu-0001: "gpu"
 
 }
 login_names = {
@@ -36,7 +59,7 @@ control_subnet = "control-subnet"
 
 login_image = "CentOS8.3_login"
 control_image = "CentOS8.3"
-compute_image = "CentOS8.3"
+compute_images = {} # allows overrides for specific nodes, by name
 
 control_flavor = "gen.c16m32s32"
 

--- a/environments/deploy/terraform/variables.tf
+++ b/environments/deploy/terraform/variables.tf
@@ -1,7 +1,12 @@
+variable "compute_types" {
+    type = map
+    description = "Mapping defining types of compute nodes: key -> (str) name of type, value -> mapping {flavor: flavor_name image: image_name_or_id }"
+}
+
 variable "compute_names" {
     type = map(string)
     default = {}
-    description = "Mapping of names -> flavor type for compute nodes (Note hostnames will be be prefixed with cluster_name)"
+    description = "Mapping of compute node name -> key in compute_types (Note nodenames are prefixed with cluster_name to make hostnames)"
 }
 
 variable "proxy_name" {
@@ -110,9 +115,10 @@ variable "control_image" {
     description = "Name of image for compute node"
 }
 
-variable "compute_image" {
-    type = string
-    description = "Name of image for compute node(s)"
+variable "compute_images" {
+    type = map(string)
+    default = {}
+    description = "Mapping to override compute images from compute_types: key ->(str) node name, value -> (str) image name"
 }
 
 variable "cluster_network_cidr" {


### PR DESCRIPTION
FAO @itd, @kbsheets 

Changes TF to support multiple compute node types:
- New TF variable `compute_types` is a mapping defining types of compute nodes. Key is a name for the type (e.g. "large", "gpu"), value is a map defining the flavor and image for this type.
- TF variable `compute_names` altered so values are now keys from `compute_types`. I.e. it maps node names to node types.
- New TF variable `compute_images` allows the the image from `compute_types` to to be overriden for specific nodes (e.g. for upgrades/testing). Key is node name (i.e. key from `compute_names`, value is image name to use.
- TF variable `compute_image` removed.

Currently setup to replicate the `nrel` branch config. Obviously the GPU image will need changing.