### PR TITLE
Add separate cluster_slurm_name TF var

### DIFF
--- a/environments/deploy/terraform/inventory.tpl
+++ b/environments/deploy/terraform/inventory.tpl
@@ -1,6 +1,6 @@
 [all:vars]
 ansible_user=centos
-openhpc_cluster_name=${cluster_name}
+openhpc_cluster_name=${cluster_slurm_name}
 ansible_ssh_common_args='-o ProxyCommand="ssh centos@${proxy_fip} -W %h:%p"'
 
 [control]
@@ -17,19 +17,19 @@ ${compute.name} ansible_host=${[for n in compute.network: n.fixed_ip_v4 if n.acc
 %{ endfor ~}
 
 ## Define groups for slurm parititions:
-[${cluster_name}_lg] 
+[${cluster_slurm_name}_lg] 
 ${cluster_name}-lg-[0001:0008]
 
-[${cluster_name}_std]
+[${cluster_slurm_name}_std]
 ${cluster_name}-std-[0001:0040]
 
-[${cluster_name}_sm]
+[${cluster_slurm_name}_sm]
 ${cluster_name}-sm-[0001:0040]
 
-[${cluster_name}_t]
+[${cluster_slurm_name}_t]
 ${cluster_name}-t-[0001:0015]
 
-[${cluster_name}_gpu]
+[${cluster_slurm_name}_gpu]
 ${cluster_name}-gpu-[0001:0006]
 
 

--- a/environments/deploy/terraform/main.tf
+++ b/environments/deploy/terraform/main.tf
@@ -347,6 +347,7 @@ resource "local_file" "hosts" {
   content  = templatefile("${path.module}/inventory.tpl",
                           {
                             "cluster_name": var.cluster_name
+                            "cluster_slurm_name": var.cluster_slurm_name
                             "proxy_fip": openstack_networking_floatingip_v2.logins[var.proxy_name].address
                             "control": openstack_compute_instance_v2.control,
                             "logins": openstack_compute_instance_v2.logins,

--- a/environments/deploy/terraform/terraform.tfvars
+++ b/environments/deploy/terraform/terraform.tfvars
@@ -157,7 +157,8 @@ login_image = "c83_login.v2"
 
 proxy_name = "login-1"
 
-cluster_name  = "vermilion"
+cluster_name  = "vs"
+cluster_slurm_name = "vermilion"
 # don't put dashes (creates invalid ansible group names) or underscores (creates hostnames which get mangled) in this
 
 key_pair = "slurmdeploy"

--- a/environments/deploy/terraform/variables.tf
+++ b/environments/deploy/terraform/variables.tf
@@ -25,6 +25,11 @@ variable "cluster_name" {
     description = "Name for cluster, used as prefix for resources"
 }
 
+variable "cluster_slurm_name" {
+    type = string
+    description = "Name for cluster in Slurm"
+}
+
 variable "cluster_network" {
     type = string
     description = "Name of pre-existing vnet to use for cluster"

--- a/environments/nrel-proto-vm/terraform/inventory.tpl
+++ b/environments/nrel-proto-vm/terraform/inventory.tpl
@@ -1,6 +1,6 @@
 [all:vars]
 ansible_user=centos
-openhpc_cluster_name=${cluster_name}
+openhpc_cluster_name=${cluster_slurm_name}
 
 [control]
 ${control.name} ansible_host=${[for n in control.network: n.fixed_ip_v4 if n.access_network][0]} server_networks='${jsonencode({for net in control.network: net.name => [ net.fixed_ip_v4 ] })}'
@@ -16,8 +16,8 @@ ${compute.name} ansible_host=${[for n in compute.network: n.fixed_ip_v4 if n.acc
 %{ endfor ~}
 
 # Define groups for slurm parititions:
-[${cluster_name}_sm]
+[${cluster_slurm_name}_sm]
 ${cluster_name}-sm-00[1:2]
 
-[${cluster_name}_ty]
+[${cluster_slurm_name}_ty]
 ${cluster_name}-ty-00[1:2]

--- a/environments/nrel-proto-vm/terraform/main.tf
+++ b/environments/nrel-proto-vm/terraform/main.tf
@@ -331,6 +331,7 @@ resource "local_file" "hosts" {
   content  = templatefile("${path.module}/inventory.tpl",
                           {
                             "cluster_name": var.cluster_name
+                            "cluster_slurm_name": var.cluster_slurm_name
                             // "proxy_fip": openstack_networking_floatingip_v2.logins[var.proxy_name].address
                             "control": openstack_compute_instance_v2.control,
                             "logins": openstack_compute_instance_v2.logins,

--- a/environments/nrel-proto-vm/terraform/terraform.tfvars
+++ b/environments/nrel-proto-vm/terraform/terraform.tfvars
@@ -26,6 +26,7 @@ login_names = {
 proxy_name = "login-0"
 
 cluster_name  = "test" # don't put dashes (creates invalid ansible group names) or underscores (creates hostnames which get mangled) in this
+cluster_slurm_name = "vermilion" # as above
 key_pair = "centos_at_nrel-deploy-vm"
 
 cluster_network = "compute"

--- a/environments/nrel-proto-vm/terraform/variables.tf
+++ b/environments/nrel-proto-vm/terraform/variables.tf
@@ -25,6 +25,11 @@ variable "cluster_name" {
     description = "Name for cluster, used as prefix for resources"
 }
 
+variable "cluster_slurm_name" {
+    type = string
+    description = "Name for cluster in Slurm"
+}
+
 variable "cluster_network" {
     type = string
     description = "Name of pre-existing vnet to use for cluster"


### PR DESCRIPTION
Allows Slurm's cluster name to be decoupled from hostnames.

a) reverts 4e989ede6c1cebdc274506ac439a256eb2740a60, changing `cluster_name` back to "vs" in terraform - as I'm assuming that is what the inventory/hosts currently have. **DO NOT APPLY if this is not the case.**
b) adds a "cluster_slurm_name" terraform var which controls the slurm side of things, while "cluster_name" still defines hostnames etc.

To apply: 
- Run terraform apply - if this plans to change anything **EXCEPT** the local_file.hosts ansible inventory file - please abort and discuss!
- Log into the slurm control node and run `sudo rm /var/spool/slurm/clustername` - else Slurm complains the cluster name has changed.
- Rerun `ansible-playbook ansible/site.yml`