### PR TITLE
Prevent FIPs being released from project on terraform destroy

### DIFF
--- a/environments/lab/terraform/main.tf
+++ b/environments/lab/terraform/main.tf
@@ -340,33 +340,19 @@ resource "openstack_compute_instance_v2" "computes" {
 
 # --- floating ips ---
 
-resource "openstack_networking_floatingip_v2" "logins" {
-
-  for_each = var.login_names
-
-  pool = data.openstack_networking_network_v2.external.name
-  # address = var.login_ips[each.key]
-}
-
 resource "openstack_compute_floatingip_associate_v2" "logins" {
   for_each = var.login_names
 
-  floating_ip = openstack_networking_floatingip_v2.logins[each.key].address
+  floating_ip = var.login_ips[each.key]
   instance_id = openstack_compute_instance_v2.logins[each.key].id
    # networks are zero-indexed
   fixed_ip = openstack_compute_instance_v2.logins[each.key].network.2.fixed_ip_v4
 
 }
 
-resource "openstack_networking_floatingip_v2" "control" {
-
-  pool = data.openstack_networking_network_v2.external.name
-  # address = var.control_ip
-}
-
 resource "openstack_compute_floatingip_associate_v2" "control" {
 
-  floating_ip = openstack_networking_floatingip_v2.control.address
+  floating_ip = var.control_ip
   instance_id = openstack_compute_instance_v2.control.id
    # networks are zero-indexed
   fixed_ip = openstack_compute_instance_v2.control.network.2.fixed_ip_v4
@@ -380,7 +366,7 @@ resource "local_file" "hosts" {
                           {
                             "cluster_name": var.cluster_name
                             "cluster_slurm_name": var.cluster_slurm_name
-                            "proxy_fip": openstack_networking_floatingip_v2.logins[var.proxy_name].address
+                            "proxy_fip": var.login_ips[var.proxy_name]
                             "control": openstack_compute_instance_v2.control,
                             "logins": openstack_compute_instance_v2.logins,
                             "computes": openstack_compute_instance_v2.computes,

--- a/environments/lab/terraform/terraform.tfvars
+++ b/environments/lab/terraform/terraform.tfvars
@@ -40,7 +40,7 @@ login_names = {
 #
 
 login_ips = {
-  login-1: "10.60.105.223"
+  login-1: "128.232.226.207"
 }
 #
 
@@ -51,7 +51,7 @@ login_flavor = "vm.ska.cpu.general.small"
 control_image = "Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2"
 control_flavor = "vm.ska.cpu.general.small"
 
-control_ip = "10.60.106.230"
+control_ip = "128.232.226.198"
 
 proxy_name = "login-1"
 

--- a/environments/prod/terraform/main.tf
+++ b/environments/prod/terraform/main.tf
@@ -340,33 +340,19 @@ resource "openstack_compute_instance_v2" "computes" {
 
 # --- floating ips ---
 
-resource "openstack_networking_floatingip_v2" "logins" {
-
-  for_each = var.login_names
-
-  pool = data.openstack_networking_network_v2.external.name
-  address = var.login_ips[each.key]
-}
-
 resource "openstack_compute_floatingip_associate_v2" "logins" {
   for_each = var.login_names
 
-  floating_ip = openstack_networking_floatingip_v2.logins[each.key].address
+  floating_ip = var.login_ips[each.key]
   instance_id = openstack_compute_instance_v2.logins[each.key].id
    # networks are zero-indexed
   fixed_ip = openstack_compute_instance_v2.logins[each.key].network.2.fixed_ip_v4
 
 }
 
-resource "openstack_networking_floatingip_v2" "control" {
-
-  pool = data.openstack_networking_network_v2.external.name
-  address = var.control_ip
-}
-
 resource "openstack_compute_floatingip_associate_v2" "control" {
 
-  floating_ip = openstack_networking_floatingip_v2.control.address
+  floating_ip = var.control_ip
   instance_id = openstack_compute_instance_v2.control.id
    # networks are zero-indexed
   fixed_ip = openstack_compute_instance_v2.control.network.2.fixed_ip_v4
@@ -380,7 +366,7 @@ resource "local_file" "hosts" {
                           {
                             "cluster_name": var.cluster_name
                             "cluster_slurm_name": var.cluster_slurm_name
-                            "proxy_fip": openstack_networking_floatingip_v2.logins[var.proxy_name].address
+                            "proxy_fip": var.login_ips[var.proxy_name]
                             "control": openstack_compute_instance_v2.control,
                             "logins": openstack_compute_instance_v2.logins,
                             "computes": openstack_compute_instance_v2.computes,

--- a/environments/vtest/terraform/main.tf
+++ b/environments/vtest/terraform/main.tf
@@ -340,33 +340,19 @@ resource "openstack_compute_instance_v2" "computes" {
 
 # --- floating ips ---
 
-resource "openstack_networking_floatingip_v2" "logins" {
-
-  for_each = var.login_names
-
-  pool = data.openstack_networking_network_v2.external.name
-  address = var.login_ips[each.key]
-}
-
 resource "openstack_compute_floatingip_associate_v2" "logins" {
   for_each = var.login_names
 
-  floating_ip = openstack_networking_floatingip_v2.logins[each.key].address
+  floating_ip = var.login_ips[each.key]
   instance_id = openstack_compute_instance_v2.logins[each.key].id
    # networks are zero-indexed
   fixed_ip = openstack_compute_instance_v2.logins[each.key].network.2.fixed_ip_v4
 
 }
 
-resource "openstack_networking_floatingip_v2" "control" {
-
-  pool = data.openstack_networking_network_v2.external.name
-  address = var.control_ip
-}
-
 resource "openstack_compute_floatingip_associate_v2" "control" {
 
-  floating_ip = openstack_networking_floatingip_v2.control.address
+  floating_ip = var.control_ip
   instance_id = openstack_compute_instance_v2.control.id
    # networks are zero-indexed
   fixed_ip = openstack_compute_instance_v2.control.network.2.fixed_ip_v4
@@ -380,7 +366,7 @@ resource "local_file" "hosts" {
                           {
                             "cluster_name": var.cluster_name
                             "cluster_slurm_name": var.cluster_slurm_name
-                            "proxy_fip": openstack_networking_floatingip_v2.logins[var.proxy_name].address
+                            "proxy_fip": var.login_ips[var.proxy_name]
                             "control": openstack_compute_instance_v2.control,
                             "logins": openstack_compute_instance_v2.logins,
                             "computes": openstack_compute_instance_v2.computes,


### PR DESCRIPTION
Prevent users outside the openstack project "stealing" the cluster's FIPs when the cluster infra is destroyed.

This is done by removing the `openstack_networking_floatingip_v2` resources and instead directly defining the addresses of FIPs to be attached to fixed IPs. This means FIPs must be manually associated to the OpenStack project, but also means they are not released from the project on `terraform destroy`.

Note experimenting showed the following will be required on applying these changes:
- Run `terraform apply`; terraform will destroy the `openstack_networking_floatingip_v2`. The FIP will be released from the project and the fixed to floating IP associations will be lost - but terraform will not error on this.
- Add the FIPs back into the project manually.
- Run `terraform apply` again. The FIPs will be reassociated with the fixed IPs.