### PR TITLE
Enable opensearch

### DIFF
--- a/environments/nrel/inventory/groups
+++ b/environments/nrel/inventory/groups
@@ -20,7 +20,7 @@ control
 [node_exporter:children]
 cluster
 
-[opendistro:children]
+[opensearch:children]
 control
 
 [slurm_stats:children]


### PR DESCRIPTION
Upstream changed from opendistro to openseach. This wasn't present in the groups file so neither was being deployed.

**IMPORTANT**: The [ansible/roles/opensearch/tasks/migrate-opendistro.yml](https://github.com/stackhpc/nrel-slurm-app/blob/prod2312-opensearch/ansible/roles/opensearch/tasks/migrate-opendistro.yml) migration playbook only runs automatically when migrating a live system. It won't work after a rebuild as there will be no opendistro unit file. So we should migrate data manually before running site.yml.