### PR TITLE
Fix podman systemd user session warnings

### DIFF
--- a/ansible/roles/filebeat/templates/filebeat.service.j2
+++ b/ansible/roles/filebeat/templates/filebeat.service.j2
@@ -12,7 +12,7 @@ After=network-online.target
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=always
-ExecStart=/usr/bin/podman run \
+ExecStart=/usr/bin/podman --cgroup-manager=cgroupfs run \
     --network=host \
     --sdnotify=conmon \
     --cgroups=no-conmon \

--- a/ansible/roles/mysql/templates/mysql.service.j2
+++ b/ansible/roles/mysql/templates/mysql.service.j2
@@ -14,7 +14,7 @@ EnvironmentFile=/etc/sysconfig/mysqld
 # The above EnvironmentFile must define MYSQL_INITIAL_ROOT_PASSWORD
 ExecStartPre=+install -d -o {{ mysql_podman_user }} -g {{ mysql_podman_user }} -Z container_file_t {{ mysql_datadir }}
 ExecStartPre=+chown -R {{ mysql_podman_user }}:{{ mysql_podman_user }} {{ mysql_datadir }}
-ExecStart=/usr/bin/podman run \
+ExecStart=/usr/bin/podman --cgroup-manager=cgroupfs run \
     --network=host \
     --sdnotify=conmon \
     --cgroups=no-conmon \

--- a/ansible/roles/opensearch/templates/opensearch.service.j2
+++ b/ansible/roles/opensearch/templates/opensearch.service.j2
@@ -11,7 +11,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=always
 # paths below based on https://opensearch.org/docs/latest/opensearch/configuration/ and https://opensearch.org/docs/latest/security-plugin/configuration/yaml
 # see also https://opensearch.org/docs/2.0/opensearch/install/important-settings/
-ExecStart=/usr/bin/podman run \
+ExecStart=/usr/bin/podman --cgroup-manager=cgroupfs run \
     --network=host \
     --sdnotify=conmon \
     --cgroups=no-conmon \


### PR DESCRIPTION
Cherry-pick [15f9ab3](https://github.com/stackhpc/ansible-slurm-appliance/pull/353/commits/15f9ab38f9c3721494e49ca37c594fef085ce2dc) to fix warnings about a lack of systemd user sessions. See the [RL9 PR](https://github.com/stackhpc/ansible-slurm-appliance/pull/353) this comes from for more info.