### PR TITLE
Template out /etc/hosts in all environments

### DIFF
--- a/environments/lab/inventory/extra_groups
+++ b/environments/lab/inventory/extra_groups
@@ -1,7 +1,3 @@
 # Don't have os_manila for lab so fake it using NFS
 [nfs:children]
 openhpc
-
-# Don't have working internal DNS
-[etc_hosts:children]
-cluster

--- a/environments/nrel/inventory/groups
+++ b/environments/nrel/inventory/groups
@@ -65,4 +65,6 @@ fail2ban
 # # Subset of compute to run a Jupyter Notebook servers on via Open Ondemand
 # compute
 
-
+# Don't have working internal DNS
+[etc_hosts:children]
+cluster


### PR DESCRIPTION
It looks like some environments used to do this using a pre- hook, then it got removed, then it was added back in for the lab. The appliance now contains an `etc_hosts` role so all environments can use that instead of a hook.

